### PR TITLE
21 set si position of fov relative to where the last scan was done

### DIFF
--- a/src/shimTool/Tool.py
+++ b/src/shimTool/Tool.py
@@ -618,6 +618,8 @@ class Tool:
         cvs = {"act_tr": 6000, "act_te": 1104, "rhrcctrl": 13, "rhimsize": 64}
         for i in range(2):
             self.exsiInstance.sendSelTask()
+            self.exsiInstance.sendSetScanPlaneOrientation()
+            self.exsiInstance.sendSetCenterPosition()
             self.exsiInstance.sendActTask()
             for cv in cvs.keys():
                 if cv == "act_te":
@@ -726,6 +728,8 @@ class Tool:
         if self.exsiInstance and not self.assetCalibrationDone:
             self.exsiInstance.sendLoadProtocol("ConformalShimCalibration4")  # TODO rename the sequences on the scanner
             self.exsiInstance.sendSelTask()
+            self.exsiInstance.sendSetScanPlaneOrientation("axial")
+            self.exsiInstance.sendSetCenterPosition("axial")
             self.exsiInstance.sendActTask()
             self.exsiInstance.sendPatientTable()
             self.exsiInstance.sendScan()
@@ -743,6 +747,8 @@ class Tool:
         if self.exsiInstance:
             self.exsiInstance.sendLoadProtocol("ConformalShimCalibration5")
             self.exsiInstance.sendSelTask()
+            self.exsiInstance.sendSetScanPlaneOrientation()
+            self.exsiInstance.sendSetCenterPosition()
             self.exsiInstance.sendActTask()
             self.exsiInstance.sendPatientTable()
             self.exsiInstance.sendScan()

--- a/src/shimTool/exsi_client.py
+++ b/src/shimTool/exsi_client.py
@@ -57,6 +57,7 @@ class exsi:
         self.examNumber = None
         self.ogCenterFrequency = None
         self.ogLinearGradients = None
+        self.bedPosition = None
         self.patientName = None
 
         # function passed from GUI to directly queue a shimSetCurrentManual command
@@ -425,19 +426,33 @@ class exsi:
         self.send(f"WaitImagesReady")
 
     @requireExsiConnected
-    def sendSetScanPlaneOrientation(self, plane:str):
+    def sendSetScanPlaneOrientation(self, plane:str=None):
         """plane: str, one of 'coronal', 'sagittal', 'axial'"""
+        if plane is None:
+            plane = "coronal"
         self.send(f"SetRxGeometry plane={plane}")
 
     @requireExsiConnected
-    def sendSetCenterPosition(self, center:list[float], plane:str):
+    def sendSetCenterPosition(self, plane=None, center=None):
         """
         center: list[float], [r/l,a/p,s/i]
         plane: str, one of 'coronal', 'sagittal', 'axial'
+
+        if they are not provided, it defaults to the last bed position in S/I direction and zero otherwise
+        the plane defaults to coronal
         """
         def helper(triple):
             return f"{triple[0]},{triple[1]},{triple[2]}"
 
+        print(f"plane is {plane}, center is {center}")
+        if plane is None:
+            plane = "coronal"
+        if center is None:
+            if self.bedPosition is None:
+                self.getLastSetBedPosition()
+            center = [0.0,0.0,self.bedPosition]
+
+        print(f"plane is {plane}, center is {center}")
         if plane=="coronal":
             phaseNormal = [10,0,0]
             freqNormal = [0,0,10]


### PR DESCRIPTION
reiterating from the issue thread: 

Things to consider about this merge:

This new functionality adheres to users following this **easy shim goal**:
1. first the user will select their desired fov on the scanner. 
2. then they will move the scanner bed to that position
3. then the tool will simply use that scanner bed as the center of all of its future calibrations and shimming operations.
4. the current state of this quick solution means that you will not be able to change the position / thing you wish to scan without re-calibrating the shims. (that is until the linear gradients are paremetrized and their basis maps are not necessarily acquired every single time)

